### PR TITLE
[#15] Generate documentation in MetricsHub Community Connectors using MetricsHub Connector Maven Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 .mvn/wrapper/maven-wrapper.jar
+
+# IntelliJ IDEA files
+*.iml
+.idea/
+*.iws
+*.ipr
+

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,13 @@
 				<version>3.4.5</version>
 			</plugin>
 
+			<!-- The MetricsHub Connector Maven Plugin -->
+			<plugin>
+				<groupId>org.sentrysoftware.maven</groupId>
+				<artifactId>metricshub-connector-maven-plugin</artifactId>
+				<version>1.0.00-SNAPSHOT</version>
+			</plugin>
+
 		</plugins>
 	</reporting>
 

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -1,0 +1,24 @@
+.community-connector-class code[class*=language-js] {
+    background-color: #f9f2f4;
+    color: #c7254e;
+}
+
+.community-connector-class code[class*=language-js] .token.punctuation {
+    color: #a1a1a1;
+}
+
+.community-connector-class code[class*=language-js] .token.operator {
+    color: #3e3f58;
+}
+
+.community-connector-class code[class*=language-js] .token.string {
+    color: #c96a43;
+}
+
+.community-connector-class code[class*=language-js]::selection,
+.community-connector-class code[class*=language-js] ::selection
+{
+    text-shadow: none;
+    background: #4f62ad;
+    color: white;
+}

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -10,6 +10,7 @@
 	<custom>
 		<noDefaultLinks>true</noDefaultLinks>
 		<keywords>metricshub, community, connector, hardware, system</keywords>
+		<bodyClass>community-connector-class</bodyClass>
 	</custom>
 
 	<bannerLeft>
@@ -25,6 +26,11 @@
 
 		<menu name="User Documentation">
 			<item name="Getting Started" href="index.html" />
+		</menu>
+
+		<menu name="MetricsHub Connectors">
+			<item name="Supported Platforms" href="platform-requirements.html " />
+			<item name="Reference" href="metricshub-connector-reference.html"/>
 		</menu>
 
 		<menu ref="reports" />


### PR DESCRIPTION
* Add MetricsHub Connector Maven Plugin configuration to pom.xml file.
* Update site.xml to generate documentation.
* Add bodyClass for better styling in site.xml file.
* Create site.css for consistent colors in syntax highlighting.