### PR TITLE
Issue #43: Update detection criteria for VMware ESXi Disks (IPMI and Storage)

### DIFF
--- a/src/main/connector/hardware/VMwareESXiDisksIPMI/VMwareESXiDisksIPMI.yaml
+++ b/src/main/connector/hardware/VMwareESXiDisksIPMI/VMwareESXiDisksIPMI.yaml
@@ -19,7 +19,7 @@ connector:
     - type: wbem
       namespace: root/cimv2
       query: SELECT MajorVersion FROM VMware_HypervisorSoftwareIdentity
-      expectedResult: ^[34567]
+      expectedResult: ^[1-9][0-9]\\|[4-9]
     # Check that there are sensors of IPMI Type 13 and SensorType 11 (Presence)
     - type: wbem
       namespace: root/cimv2

--- a/src/main/connector/hardware/VMwareESXiDisksIPMI/VMwareESXiDisksIPMI.yaml
+++ b/src/main/connector/hardware/VMwareESXiDisksIPMI/VMwareESXiDisksIPMI.yaml
@@ -19,7 +19,7 @@ connector:
     - type: wbem
       namespace: root/cimv2
       query: SELECT MajorVersion FROM VMware_HypervisorSoftwareIdentity
-      expectedResult: ^[1-9][0-9]\\|[4-9]
+      expectedResult: ^\\([1-9][0-9]\\|[4-9]\\)
     # Check that there are sensors of IPMI Type 13 and SensorType 11 (Presence)
     - type: wbem
       namespace: root/cimv2

--- a/src/main/connector/hardware/VMwareESXiDisksStorage/VMwareESXiDisksStorage.yaml
+++ b/src/main/connector/hardware/VMwareESXiDisksStorage/VMwareESXiDisksStorage.yaml
@@ -21,7 +21,7 @@ connector:
     - type: wbem
       namespace: root/cimv2
       query: SELECT MajorVersion FROM VMware_HypervisorSoftwareIdentity
-      expectedResult: "^[34567]"
+      expectedResult: ^[1-9][0-9]\\|[4-9]
     # Check that there are ESX Disks (Storage Extents)
     - type: wbem
       namespace: root/cimv2

--- a/src/main/connector/hardware/VMwareESXiDisksStorage/VMwareESXiDisksStorage.yaml
+++ b/src/main/connector/hardware/VMwareESXiDisksStorage/VMwareESXiDisksStorage.yaml
@@ -21,7 +21,7 @@ connector:
     - type: wbem
       namespace: root/cimv2
       query: SELECT MajorVersion FROM VMware_HypervisorSoftwareIdentity
-      expectedResult: ^[1-9][0-9]\\|[4-9]
+      expectedResult: ^\\([1-9][0-9]\\|[4-9]\\)
     # Check that there are ESX Disks (Storage Extents)
     - type: wbem
       namespace: root/cimv2


### PR DESCRIPTION
Update detection criteria for VMware ESXi Disks (IPMI and Storage)

- Update detection criteria to include version 8