### PR TITLE
Issue #47: Added `file_system` type for Windows system

### DIFF
--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -128,7 +128,7 @@ monitors:
         fileSystemInformation:
           type: wmi
           namespace: root\CIMv2
-          query: SELECT DeviceID,FreeSpace,FreeSpace,Size,Size,VolumeName FROM Win32_LogicalDisk WHERE DriveType = 3
+          query: SELECT DeviceID,FreeSpace,FreeSpace,Size,Size,VolumeName,FileSystem FROM Win32_LogicalDisk WHERE DriveType = 3
           computes:
           - type: subtract
             column: 4
@@ -147,6 +147,7 @@ monitors:
           id: $1
           system.filesystem.device: $1
           system.filesystem.volumeName: $7
+          system.filesystem.type: $8
         metrics:
           system.filesystem.usage{system.filesystem.state="free"}: $2
           system.filesystem.usage{system.filesystem.state="used"}: $4


### PR DESCRIPTION
Updated the `Win32_LogicalDisk` query to add the file system type. 
Updated the `file_system` monitor's mapping to collect the `system.filesystem.type` attribute.