### PR TITLE
Issue #69: Use MetricsHub Connector Maven Plugin version 1.0.02

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
 			<plugin>
 				<groupId>org.sentrysoftware.maven</groupId>
 				<artifactId>metricshub-connector-maven-plugin</artifactId>
-				<version>1.0.00</version>
+				<version>1.0.02</version>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
* Updated report plugin section to use `metricshub-connector-maven-plugin` version 1.0.02.