### PR TITLE
Issue #69: Use MetricsHub Connector Maven Plugin version 1.0.03

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
 			<plugin>
 				<groupId>org.sentrysoftware.maven</groupId>
 				<artifactId>metricshub-connector-maven-plugin</artifactId>
-				<version>1.0.02</version>
+				<version>1.0.03</version>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
* Updated POM to use Connector Maven Plugin version 1.0.03 for the documentation.