### PR TITLE
Issue #85: Added new metrics system.uptime

### DIFF
--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -235,16 +235,8 @@ monitors:
         osInformation:
           type: commandLine
           commandLine: |
-            os_info=$(cat /etc/os-release | grep -E '^(NAME|VERSION="[0-9].*")' | tr -d '"')
-            kernel_version=$(cat /proc/version | awk '{print $3}')
-            echo "$os_info; $kernel_version"
-          computes:
-          - type: awk
-            script: BEGIN { FS = "=" } { printf $2 ";"}
-        # Uptime (timestamp)
-        uptime:
-          type: commandLine
-          commandLine: expr $(date +%s) - $(awk '{print int($1)}' /proc/uptime)
+            . /etc/os-release
+            echo "$NAME;$VERSION;`uname -r`;`cut -d. -f1 /proc/uptime`"
       mapping:
         source: ${source::osInformation}
         attributes:
@@ -253,7 +245,7 @@ monitors:
           version: $2
           os_version: $3
         metrics:
-          system.uptime: ${source::uptime}
+          system.uptime: $4
 translations:
   serviceLoadedTranslationTable:
     not-found: "0"

--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -228,6 +228,32 @@ monitors:
           system.filesystem.usage{system.filesystem.state=free}: $5
           system.filesystem.utilization{system.filesystem.state=used}: $6
           system.filesystem.utilization{system.filesystem.state=free}: $7
+  system:
+    simple:
+      sources:
+        # Distribution;Version;Kernel
+        osInformation:
+          type: commandLine
+          commandLine: |
+            os_info=$(cat /etc/os-release | grep -E '^(NAME|VERSION="[0-9].*")' | tr -d '"')
+            kernel_version=$(cat /proc/version | awk '{print $3}')
+            echo "$os_info; $kernel_version"
+          computes:
+          - type: awk
+            script: BEGIN { FS = "=" } { printf $2 ";"}
+        # Uptime (timestamp)
+        uptime:
+          type: commandLine
+          commandLine: expr $(date +%s) - $(awk '{print int($1)}' /proc/uptime)
+      mapping:
+        source: ${source::osInformation}
+        attributes:
+          id: $3
+          name: $1
+          version: $2
+          os_version: $3
+        metrics:
+          system.uptime: ${source::uptime}
 translations:
   serviceLoadedTranslationTable:
     not-found: "0"

--- a/src/main/connector/system/System/System.yaml
+++ b/src/main/connector/system/System/System.yaml
@@ -123,3 +123,7 @@ metrics:
     description: An estimate of how much memory is available for starting new applications, without causing swapping
     type: UpDownCounter
     unit: By  
+  system.uptime:
+    description: Timestamp of the system's last startup.
+    type: Gauge
+    unit: s

--- a/src/main/connector/system/System/System.yaml
+++ b/src/main/connector/system/System/System.yaml
@@ -124,6 +124,6 @@ metrics:
     type: UpDownCounter
     unit: By  
   system.uptime:
-    description: Timestamp of the system's last startup.
+    description: System uptime in seconds indicates how long the host has been running since its last boot
     type: Gauge
     unit: s

--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -277,16 +277,20 @@ monitors:
   system:
     simple:
       sources:
-        # SerialNumber;Caption;Version;BuildNumber
-        osInformation:
-          type: wmi
-          namespace: root\CIMv2
-          query: SELECT SerialNumber, Caption, Version, BuildNumber FROM Win32_OperatingSystem
         # Uptime
         uptime:
           type: wmi
           namespace: root\CIMv2
           query: SELECT SystemUpTime FROM Win32_PerfFormattedData_PerfOS_System
+        # SerialNumber;Caption;Version;BuildNumber
+        osInformation:
+          type: wmi
+          namespace: root\CIMv2
+          query: SELECT SerialNumber, Caption, Version, BuildNumber FROM Win32_OperatingSystem
+          computes:
+          - type: prepend
+            column: 5
+            value: ${source::uptime}
       mapping:
         source: ${source::osInformation}
         attributes:
@@ -296,4 +300,4 @@ monitors:
           version: $4
           os_version: $3
         metrics:
-          system.uptime: ${source::uptime}
+          system.uptime: $5

--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -282,11 +282,11 @@ monitors:
           type: wmi
           namespace: root\CIMv2
           query: SELECT SerialNumber, Caption, Version, BuildNumber FROM Win32_OperatingSystem
-        # Uptime (timestamp)
+        # Uptime
         uptime:
           type: wmi
           namespace: root\CIMv2
-          query: SELECT LastBootUpTime FROM Win32_OperatingSystem
+          query: SELECT SystemUpTime FROM Win32_PerfFormattedData_PerfOS_System
       mapping:
         source: ${source::osInformation}
         attributes:

--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -274,3 +274,26 @@ monitors:
           system.disk.io_time: $6
           system.disk.operation_time{disk.io.direction="read"}: $7
           system.disk.operation_time{disk.io.direction="write"}: $8
+  system:
+    simple:
+      sources:
+        # SerialNumber;Caption;Version;BuildNumber
+        osInformation:
+          type: wmi
+          namespace: root\CIMv2
+          query: SELECT SerialNumber, Caption, Version, BuildNumber FROM Win32_OperatingSystem
+        # Uptime (timestamp)
+        uptime:
+          type: wmi
+          namespace: root\CIMv2
+          query: SELECT LastBootUpTime FROM Win32_OperatingSystem
+      mapping:
+        source: ${source::osInformation}
+        attributes:
+          id: $1
+          serial_number: $1
+          name: $2
+          version: $4
+          os_version: $3
+        metrics:
+          system.uptime: ${source::uptime}


### PR DESCRIPTION
The system_uptime metric provides the timestamp of the system's last boot. This metric is crucial for monitoring the system's uptime by offering the exact time at which the system was last restarted. Additionally, this metric includes labels that provide detailed information about the operating system.

Labels:

- name: The name of the operating system (e.g., "Debian GNU/Linux", "Microsoft Windows Server 2019 Standard")
- os_version: The version of the operating system (e.g., "6.1.0-18-amd64", "10.0.17763").
- version: The detailed version or release name of the OS (e.g., "12 (bookworm)", "17763").
- Value: The metric value is a timestamp representing the last boot time of the system, formatted in Unix epoch time.
