### PR TITLE
Issue #122: Add default values for connector variables 

### DIFF
--- a/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
+++ b/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
@@ -20,13 +20,13 @@ connector:
     tags: [ system, linux ]
   variables:
     matchName:
-      description: Regular expression that process names must match to be monitored.
+      description: Regular expression pattern to match process names to monitor.
       defaultValue: .* 
     matchCommand:
-      description: Regular expression that the command line of the process must match to be monitored.
+      description: Regular expression pattern to match process command lines for monitoring.
       defaultValue: .*
     matchUser:
-      description: Regular expression that the user of the process must match to be monitored.
+      description: Regular expression pattern to match process users for inclusion.
       defaultValue: .*
 monitors:
   process:

--- a/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
+++ b/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
@@ -18,6 +18,16 @@ connector:
       expectedResult: /bin/ps
       errorMessage: Not a valid Linux host.
     tags: [ system, linux ]
+  variables:
+    matchName:
+      description: Regular expression that process names must match to be monitored.
+      defaultValue: .* 
+    matchCommand:
+      description: Regular expression that the command line of the process must match to be monitored.
+      defaultValue: .*
+    matchUser:
+      description: Regular expression that the user of the process must match to be monitored.
+      defaultValue: .*
 monitors:
   process:
     simple:

--- a/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
+++ b/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
@@ -20,7 +20,7 @@ connector:
     tags: [ system, linux ]
   variables:
     matchName:
-      description: Regular expression pattern to match process names to monitor.
+      description: Regular expression pattern to match process names for monitoring.
       defaultValue: .* 
     matchCommand:
       description: Regular expression pattern to match process command lines for monitoring.

--- a/src/main/connector/system/LinuxService/LinuxService.yaml
+++ b/src/main/connector/system/LinuxService/LinuxService.yaml
@@ -27,7 +27,7 @@ connector:
     tags: [ system, linux ]
   variables:
     serviceNames:
-      description: the regular expression used to match the name of services to be monitored.
+      description: Regular expression pattern to identify the services to monitor.
       defaultValue: .*
 monitors:
   service:

--- a/src/main/connector/system/LinuxService/LinuxService.yaml
+++ b/src/main/connector/system/LinuxService/LinuxService.yaml
@@ -25,6 +25,10 @@ connector:
       expectedResult: UNIT
       errorMessage: Not a valid Linux host.
     tags: [ system, linux ]
+  variables:
+    serviceNames:
+      description: the regular expression used to match the name of services to be monitored.
+      defaultValue: .*
 monitors:
   service:
     simple:

--- a/src/main/connector/system/WindowsProcess/WindowsProcess.yaml
+++ b/src/main/connector/system/WindowsProcess/WindowsProcess.yaml
@@ -15,10 +15,10 @@ connector:
     tags: [ system, windows ]
   variables:
     matchName:
-      description: Regular expression that process names must match to be monitored.
+      description: Regular expression pattern to match process names for monitoring.
       defaultValue: .* 
     matchCommand:
-      description: Regular expression that the command line of the process must match to be monitored.
+      description: Regular expression pattern to match process command lines for monitoring.
       defaultValue: .*
 monitors:
   process:

--- a/src/main/connector/system/WindowsProcess/WindowsProcess.yaml
+++ b/src/main/connector/system/WindowsProcess/WindowsProcess.yaml
@@ -13,6 +13,13 @@ connector:
       namespace: root\CIMv2
       query: SELECT Name FROM Win32_OperatingSystem
     tags: [ system, windows ]
+  variables:
+    matchName:
+      description: Regular expression that process names must match to be monitored.
+      defaultValue: .* 
+    matchCommand:
+      description: Regular expression that the command line of the process must match to be monitored.
+      defaultValue: .*
 monitors:
   process:
     simple:

--- a/src/main/connector/system/WindowsService/WindowsService.yaml
+++ b/src/main/connector/system/WindowsService/WindowsService.yaml
@@ -31,7 +31,7 @@ connector:
     tags: [ system, windows ]
   variables:
     serviceNames:
-      description: the regular expression used to match the name of services to be monitored.
+      description: Regular expression pattern to identify the services to monitor.
       defaultValue: .*
 monitors:
   service:

--- a/src/main/connector/system/WindowsService/WindowsService.yaml
+++ b/src/main/connector/system/WindowsService/WindowsService.yaml
@@ -29,6 +29,10 @@ connector:
       namespace: root\CIMv2
       query: SELECT * FROM Win32_OperatingSystem
     tags: [ system, windows ]
+  variables:
+    serviceNames:
+      description: the regular expression used to match the name of services to be monitored.
+      defaultValue: .*
 monitors:
   service:
     simple:


### PR DESCRIPTION
* Added connector variables default values on `LinuxService`, `LinuxProcess`, `WindowsService` & `WindowsProcess`.
* Tested these connectors on MetricsHub Agent.

# Testing on WindowsProcess

<img width="1341" alt="Issue #122 Community Connectors" src="https://github.com/user-attachments/assets/9ed36f0f-bdc9-4553-be54-81e633e55b9b">

Tested all the modified connectors as well, everything worked perfectly!
