### PR TITLE
Issue #125: Disable automatic detection

### DIFF
--- a/src/main/connector/system/LinuxService/LinuxService.yaml
+++ b/src/main/connector/system/LinuxService/LinuxService.yaml
@@ -19,6 +19,7 @@ connector:
     - local
     appliesTo:
     - linux
+    disableAutoDetection: true
     criteria:
     - type: commandLine
       commandLine: /usr/bin/systemctl

--- a/src/main/connector/system/WindowsProcess/WindowsProcess.yaml
+++ b/src/main/connector/system/WindowsProcess/WindowsProcess.yaml
@@ -8,6 +8,7 @@ connector:
   detection:
     appliesTo:
     - windows
+    disableAutoDetection: true
     criteria:
     - type: wmi
       namespace: root\CIMv2

--- a/src/main/connector/system/WindowsService/WindowsService.yaml
+++ b/src/main/connector/system/WindowsService/WindowsService.yaml
@@ -24,6 +24,7 @@ connector:
     - local
     appliesTo:
     - nt
+    disableAutoDetection: true
     criteria:
     - type: wmi
       namespace: root\CIMv2


### PR DESCRIPTION

* Tdded `disableAutoDetection` for `WindowsProcess`, `WindowsService` & `LinuxService`.
* Tested on Windows

# Tests on windows
- Both WindowsProcess & WindowsService not detected.

![image](https://github.com/user-attachments/assets/26a8b648-ec1d-4dc4-937a-d7405e218396)
