### PR TITLE
Issue #132: Use `metricshub-connector-maven-plugin` version 1.0.06

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 			<plugin>
 				<groupId>org.sentrysoftware.maven</groupId>
 				<artifactId>metricshub-connector-maven-plugin</artifactId>
-				<version>1.0.05</version>
+				<version>1.0.06</version>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
This pull request includes a minor version update to the `metricshub-connector-maven-plugin` in the `pom.xml` file.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L165-R165): Updated the `metricshub-connector-maven-plugin` version from `1.0.05` to `1.0.06`.