### PR TITLE
Issue #138: Add `Parameterized` tag to `LinuxProcess`, `LinuxService`, `WindowsProcess` & `WindowsService`

### DIFF
--- a/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
+++ b/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
@@ -17,7 +17,7 @@ connector:
       commandLine: /usr/bin/which ps || /bin/which ps
       expectedResult: /bin/ps
       errorMessage: Not a valid Linux host.
-    tags: [ system, linux ]
+    tags: [ system, linux, parameterized ]
   variables:
     matchName:
       description: Regular expression pattern to match process names for monitoring.

--- a/src/main/connector/system/LinuxService/LinuxService.yaml
+++ b/src/main/connector/system/LinuxService/LinuxService.yaml
@@ -25,7 +25,7 @@ connector:
       commandLine: /usr/bin/systemctl
       expectedResult: UNIT
       errorMessage: Not a valid Linux host.
-    tags: [ system, linux ]
+    tags: [ system, linux, parameterized ]
   variables:
     serviceNames:
       description: Regular expression pattern to identify the services to monitor.

--- a/src/main/connector/system/WindowsProcess/WindowsProcess.yaml
+++ b/src/main/connector/system/WindowsProcess/WindowsProcess.yaml
@@ -13,7 +13,7 @@ connector:
     - type: wmi
       namespace: root\CIMv2
       query: SELECT Name FROM Win32_OperatingSystem
-    tags: [ system, windows ]
+    tags: [ system, windows, parameterized ]
   variables:
     matchName:
       description: Regular expression pattern to match process names for monitoring.

--- a/src/main/connector/system/WindowsService/WindowsService.yaml
+++ b/src/main/connector/system/WindowsService/WindowsService.yaml
@@ -29,7 +29,7 @@ connector:
     - type: wmi
       namespace: root\CIMv2
       query: SELECT * FROM Win32_OperatingSystem
-    tags: [ system, windows ]
+    tags: [ system, windows, parameterized ]
   variables:
     serviceNames:
       description: Regular expression pattern to identify the services to monitor.


### PR DESCRIPTION

* Added `Parameterized` tag to `LinuxProcess`, `LinuxService`, `WindowsProcess` & `WindowsService` connectors.
* Tested on MetricsHub documentation.

# Tests
![image](https://github.com/user-attachments/assets/c0127157-9445-4955-947a-878667fca665)

![image](https://github.com/user-attachments/assets/4a4fdec7-374e-4738-8d6e-135309ff6df9)
