### PR TITLE
Issue #140: Fix `Platform` typo instead of `Platforms` on `Linux` & `LinuxService`

### DIFF
--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -2,7 +2,7 @@ extends:
 - ../System/System
 connector:
   displayName: LinuxOS
-  platform: Any platform with LinuxOS
+  platforms: Any platform with LinuxOS
   reliesOn: Linux OsCommands
   information: Gives OS specific information and metrics
   detection:

--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -2,7 +2,7 @@ extends:
 - ../System/System
 connector:
   displayName: LinuxOS
-  platforms: Any platform with LinuxOS
+  platforms: Any platform running Linux
   reliesOn: Linux OsCommands
   information: Gives OS specific information and metrics
   detection:

--- a/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
+++ b/src/main/connector/system/LinuxProcess/LinuxProcess.yaml
@@ -2,7 +2,7 @@ extends:
 - ../System/System
 connector:
   displayName: Linux - Processes (ps)
-  platforms: Any Linux system
+  platforms: Any platform running Linux
   reliesOn: Linux ps command
   information: Monitors performance metrics (CPU, memory, etc.) of the processes that match the specified criteria in `matchName`, `matchCommand`, and `matchUser`.
   detection:

--- a/src/main/connector/system/LinuxService/LinuxService.yaml
+++ b/src/main/connector/system/LinuxService/LinuxService.yaml
@@ -10,7 +10,7 @@ metrics:
         - exited
 connector:
   displayName: Linux - Service (systemctl)
-  platform: Any platform with LinuxOS
+  platforms: Any platform with LinuxOS
   reliesOn: Linux OsCommands
   information: Gives OS specific service information and metrics
   detection:

--- a/src/main/connector/system/LinuxService/LinuxService.yaml
+++ b/src/main/connector/system/LinuxService/LinuxService.yaml
@@ -10,7 +10,7 @@ metrics:
         - exited
 connector:
   displayName: Linux - Service (systemctl)
-  platforms: Any platform with LinuxOS
+  platforms: Any platform running Linux
   reliesOn: Linux OsCommands
   information: Gives OS specific service information and metrics
   detection:


### PR DESCRIPTION

* Fixed the typo.
* Tested the result on metricshub doc.

# Result
![image](https://github.com/user-attachments/assets/205d7804-d53a-42da-8350-f34abf6d8208)
