### PR TITLE
Issue #148: [Linux] Enhance filesystem utilization calculation

### DIFF
--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -150,7 +150,7 @@ monitors:
           commandLine: /usr/bin/df -B1 --output=source,target,fstype,used,avail,size
           computes:
           - type: awk
-            script: NR > 1 {print $1 "(" $2 ")" ";" $2 ";" $3 ";" $4 ";" $5 ";" $4 / $6 ";" $5 / $6}
+            script: NR > 1 {print $1 "(" $2 ")" ";" $2 ";" $3 ";" $4 ";" $5 ";" $4 / ($4 + $5) ";" $5 / ($4 + $5)}
       mapping:
         source: ${source::fileSystemInfo}
         attributes:

--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -161,8 +161,10 @@ monitors:
         metrics:
           system.filesystem.usage{system.filesystem.state="used"}: $4
           system.filesystem.usage{system.filesystem.state="free"}: $5
+          system.filesystem.usage{system.filesystem.state="reserved"}: $8
           system.filesystem.utilization{system.filesystem.state="used"}: $6
           system.filesystem.utilization{system.filesystem.state="free"}: $7
+          system.filesystem.utilization{system.filesystem.state="reserved"}: $9
   system:
     simple:
       sources:

--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -150,7 +150,7 @@ monitors:
           commandLine: /usr/bin/df -B1 --output=source,target,fstype,used,avail,size
           computes:
           - type: awk
-            script: NR > 1 {print $1 "(" $2 ")" ";" $2 ";" $3 ";" $4 ";" $5 ";" $4 / ($4 + $5) ";" $5 / ($4 + $5)}
+            script: NR > 1 {print $1 "(" $2 ")" ";" $2 ";" $3 ";" $4 ";" $5 ";" $4 / $6 ";" $5 / $6 ";" $6 - ($4 + $5) ";" ($6 - ($4 + $5)) / $6}
       mapping:
         source: ${source::fileSystemInfo}
         attributes:


### PR DESCRIPTION
This pull request includes an important update to the `src/main/connector/system/Linux/Linux.yaml` file, specifically within the `monitors` section. The change modifies the `awk` script used for processing disk usage information.

Key change:

* [`src/main/connector/system/Linux/Linux.yaml`](diffhunk://#diff-6d6e70c25f3246a9ae9889d976c332be4895e49b0b7605cbabe6dbc9f2ab4fa9L153-R153): Updated the `awk` script to correctly calculate the percentage of used and available space by using the sum of used and available space as the denominator.

Testing:
![image](https://github.com/user-attachments/assets/4110008a-da33-4159-93ac-a0980beacfae)
```bash
root@nb-debian:/opt/workspace/opentelemetry-collector-contrib# /usr/bin/df -B1
Filesystem       1B-blocks        Used  Available Use% Mounted on
udev            2053718016           0 2053718016   0% /dev
tmpfs            413818880    41848832  371970048  11% /run
/dev/sda1      42091429888 32452136960 7574675456  82% /
tmpfs           2069078016           0 2069078016   0% /dev/shm
tmpfs              5242880           0    5242880   0% /run/lock
tmpfs           2069078016           0 2069078016   0% /sys/fs/cgroup
tmpfs            413814784           0  413814784   0% /run/user/0
```