### PR TITLE
Issue #169: MIB2, MIB2Switch, MIB2NT: Add interface ID, name, and alias as attributes

### DIFF
--- a/src/main/connector/hardware/MIB2/MIB2.yaml
+++ b/src/main/connector/hardware/MIB2/MIB2.yaml
@@ -48,7 +48,6 @@ monitors:
         source: ${source::monitors.network.discovery.sources.source(3)}
         attributes:
           id: $1
-          hw.network.id: $1
           __display_id: $8
           physical_address: $4
           physical_address_type: MAC
@@ -57,4 +56,3 @@ monitors:
           name: ${awk::sprintf("%s (%s)", $7, $3)}
           hw.network.name: $8
           hw.network.alias: $9
-

--- a/src/main/connector/hardware/MIB2/MIB2.yaml
+++ b/src/main/connector/hardware/MIB2/MIB2.yaml
@@ -54,7 +54,7 @@ monitors:
           physical_address_type: MAC
           device_type: $3
           hw.parent.type: enclosure
-          name: $8
+          name: ${awk::sprintf("%s (%s)", $7, $3)}
           hw.network.name: $8
           hw.network.alias: $9
 

--- a/src/main/connector/hardware/MIB2/MIB2.yaml
+++ b/src/main/connector/hardware/MIB2/MIB2.yaml
@@ -54,6 +54,7 @@ monitors:
           physical_address_type: MAC
           device_type: $3
           hw.parent.type: enclosure
+          name: $8
           hw.network.name: $8
           hw.network.alias: $9
 

--- a/src/main/connector/hardware/MIB2/MIB2.yaml
+++ b/src/main/connector/hardware/MIB2/MIB2.yaml
@@ -48,9 +48,12 @@ monitors:
         source: ${source::monitors.network.discovery.sources.source(3)}
         attributes:
           id: $1
+          hw.network.id: $1
           __display_id: $8
           physical_address: $4
           physical_address_type: MAC
           device_type: $3
           hw.parent.type: enclosure
-          name:  ${awk::sprintf("%s (%s)", $7, $3)}
+          hw.network.name: $8
+          hw.network.alias: $9
+

--- a/src/main/connector/hardware/MIB2NT/MIB2NT.yaml
+++ b/src/main/connector/hardware/MIB2NT/MIB2NT.yaml
@@ -49,7 +49,7 @@ monitors:
           physical_address_type: MAC
           device_type: $3
           hw.parent.type: enclosure
-          name: $8
+          name: ${awk::sprintf("%s (%s - %s)", $8, $3, $2)}
           hw.network.name: $8
           hw.network.alias: $9
     collect:

--- a/src/main/connector/hardware/MIB2NT/MIB2NT.yaml
+++ b/src/main/connector/hardware/MIB2NT/MIB2NT.yaml
@@ -42,13 +42,15 @@ monitors:
         source: ${source::monitors.network.discovery.sources.source(3)}
         attributes:
           id: $1
+          hw.network.id: $1
           __display_id: $8
           vendor: $2
           physical_address: $4
           physical_address_type: MAC
           device_type: $3
           hw.parent.type: enclosure
-          name: ${awk::sprintf("%s (%s - %s)", $8, $3, $2)}
+          hw.network.name: $8
+          hw.network.alias: $9
     collect:
       sources:
         source(1):

--- a/src/main/connector/hardware/MIB2NT/MIB2NT.yaml
+++ b/src/main/connector/hardware/MIB2NT/MIB2NT.yaml
@@ -49,6 +49,7 @@ monitors:
           physical_address_type: MAC
           device_type: $3
           hw.parent.type: enclosure
+          name: $8
           hw.network.name: $8
           hw.network.alias: $9
     collect:

--- a/src/main/connector/hardware/MIB2NT/MIB2NT.yaml
+++ b/src/main/connector/hardware/MIB2NT/MIB2NT.yaml
@@ -42,7 +42,6 @@ monitors:
         source: ${source::monitors.network.discovery.sources.source(3)}
         attributes:
           id: $1
-          hw.network.id: $1
           __display_id: $8
           vendor: $2
           physical_address: $4

--- a/src/main/connector/hardware/MIB2Switch/MIB2Switch.yaml
+++ b/src/main/connector/hardware/MIB2Switch/MIB2Switch.yaml
@@ -58,7 +58,7 @@ monitors:
           device_type: $5
           hw.parent.type: enclosure
           hw.parent.id: ${constant::_DEVICE_ID}
-          name: $10
+          name: ${awk::sprintf("%s (%s)", $9, $5)}
           hw.network.name: $10
           hw.network.alias: $11
         conditionalCollection:

--- a/src/main/connector/hardware/MIB2Switch/MIB2Switch.yaml
+++ b/src/main/connector/hardware/MIB2Switch/MIB2Switch.yaml
@@ -58,6 +58,7 @@ monitors:
           device_type: $5
           hw.parent.type: enclosure
           hw.parent.id: ${constant::_DEVICE_ID}
+          name: $10
           hw.network.name: $10
           hw.network.alias: $11
         conditionalCollection:

--- a/src/main/connector/hardware/MIB2Switch/MIB2Switch.yaml
+++ b/src/main/connector/hardware/MIB2Switch/MIB2Switch.yaml
@@ -51,12 +51,14 @@ monitors:
         source: ${source::monitors.network.discovery.sources.source(5)}
         attributes:
           id: $1
+          hw.network.id: $1
           __display_id: $10
           physical_address: $6
           physical_address_type: MAC
           device_type: $5
           hw.parent.type: enclosure
           hw.parent.id: ${constant::_DEVICE_ID}
-          name: ${awk::sprintf("%s (%s)", $9, $5)}
+          hw.network.name: $10
+          hw.network.alias: $11
         conditionalCollection:
           hw.network.bandwidth.limit: $8

--- a/src/main/connector/hardware/MIB2Switch/MIB2Switch.yaml
+++ b/src/main/connector/hardware/MIB2Switch/MIB2Switch.yaml
@@ -51,7 +51,6 @@ monitors:
         source: ${source::monitors.network.discovery.sources.source(5)}
         attributes:
           id: $1
-          hw.network.id: $1
           __display_id: $10
           physical_address: $6
           physical_address_type: MAC


### PR DESCRIPTION
*  Updated MIB2, MIB2NT and MIB2Switch

### Tested: 
#### MIB2: 
##### Before: 
![Capture d'écran 2025-02-06 173622](https://github.com/user-attachments/assets/33b9b0b5-233b-4a09-9fee-56d00504a2dd)

##### After: 
![Capture d'écran 2025-02-06 173940](https://github.com/user-attachments/assets/a60dca40-effe-4125-b39b-7b125b13531f)

#### MIB2Switch: 
##### Before: 
![Capture d'écran 2025-02-06 153133](https://github.com/user-attachments/assets/e44a00f0-2a93-4ae3-92e4-7233153af1b5)
##### After: 
![Capture d'écran 2025-02-06 153919](https://github.com/user-attachments/assets/917e36e4-4992-4d20-afbc-ac2788dcfe07)

#### MIB2NT:
##### Before: 
![Capture d'écran 2025-02-06 180651](https://github.com/user-attachments/assets/fab926cf-ae3b-44e3-8d0f-afc8c35a39de)

##### After:
![Capture d'écran 2025-02-07 093121](https://github.com/user-attachments/assets/5d184126-c6c6-45ae-9993-f672d2e23747)
