### PR TITLE
LinuxOs and WindowsOs connectors should use network.interface.name for system.network metrics

### DIFF
--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -103,6 +103,7 @@ monitors:
         source: ${source::networkInformation}
         attributes:
           id: $1
+          network.interface.name: $1
         metrics:
           system.network.dropped{network.io.direction="transmit"}: $13
           system.network.dropped{network.io.direction="receive"}: $7

--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -208,6 +208,7 @@ monitors:
         source: ${source::networkInformation}
         attributes:
           id: $1
+          network.interface.name: $1
         metrics:
           system.network.dropped{network.io.direction="transmit"}: $2
           system.network.dropped{network.io.direction="receive"}: $3


### PR DESCRIPTION

* Updated `windows.yaml` and `linux.yaml` connectors to collect `network.interface.name` metric.
* Tested on MetricsHub.

# Tests
![image](https://github.com/user-attachments/assets/bf38109b-cc73-4d3b-b10f-8bb62d35cb97)
