### PR TITLE
Issue #178: Wrong `system.disk.*` metric attribute names and bad mapping syntax in LinuxOs

### DIFF
--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -133,12 +133,12 @@ monitors:
         metrics:
           system.disk.io{disk.io.direction="read"}: $2
           system.disk.io{disk.io.direction="write"}: $3
-          system.disk.operations{disk.operations.direction="read"}: $4
-          system.disk.operations{disk.operations.direction="write"}: $5
-          system.disk.merged{disk.merged.direction:"read"}: $6
-          system.disk.merged{disk.merged.direction:"write"}: $7
-          system.disk.operation.time{operation.time.direction:"read"}: $8
-          system.disk.operation.time{operation.time.direction:"write"}: $9
+          system.disk.operations{disk.io.direction="read"}: $4
+          system.disk.operations{disk.io.direction="write"}: $5
+          system.disk.merged{disk.io.direction="read"}: $6
+          system.disk.merged{disk.io.direction="write"}: $7
+          system.disk.operation.time{disk.io.direction="read"}: $8
+          system.disk.operation.time{disk.io.direction="write"}: $9
           system.disk.io_time: $10
   file_system:
     simple:


### PR DESCRIPTION

* Updated `Linux.yaml` to use `disk.io.direction`.
* Replaced `:` by `=` in the physical_disk mapping.
* Tested on Prometheus, and everything is working well after the update.

# Tests
## Before (wrong `system.disk.merged` and `system.disk.operation.time`)
![image](https://github.com/user-attachments/assets/f8981e38-cb7a-4c97-a159-9def6caf8c96)

## After
![image](https://github.com/user-attachments/assets/895daee2-a411-4fa0-8978-360e6fce09f9)
