### PR TITLE
Issue #176: LinuxOs and WindowsOs connectors should use system.device for Filesystem and Disk metrics

### DIFF
--- a/src/main/connector/system/Linux/Linux.yaml
+++ b/src/main/connector/system/Linux/Linux.yaml
@@ -156,7 +156,7 @@ monitors:
         source: ${source::fileSystemInfo}
         attributes:
           id: $1
-          system.filesystem.device: $1
+          system.device: $1
           system.filesystem.mountpoint: $2
           system.filesystem.type: $3
         metrics:

--- a/src/main/connector/system/Windows/Windows.yaml
+++ b/src/main/connector/system/Windows/Windows.yaml
@@ -132,7 +132,7 @@ monitors:
         source: ${source::fileSystemInformation}
         attributes:
           id: $1
-          system.filesystem.device: $1
+          system.device: $1
           system.filesystem.volumeName: $7
           system.filesystem.type: $8
         metrics:


### PR DESCRIPTION

* Replaced `system.filesystem.device` by `system.device` in both `linux.yaml` and `windows.yaml`.
* Tested in Prometheus.

# Tests
## Before (using `system.filesystem.device`)
![image](https://github.com/user-attachments/assets/135b0f07-d7bc-4af5-b117-255b4ca7bb67)

## After (using `system.device`)
![system device](https://github.com/user-attachments/assets/ea4b7793-66f7-4a5d-a45a-9b30f4c559dc)
