### PR TITLE
Issue #193: Add name and alias to connector GenericSwitchEnclosure

### DIFF
--- a/src/main/connector/hardware/GenericSwitchEnclosure/GenericSwitchEnclosure.yaml
+++ b/src/main/connector/hardware/GenericSwitchEnclosure/GenericSwitchEnclosure.yaml
@@ -68,3 +68,5 @@ monitors:
           hw.parent.type: enclosure
           hw.parent.id: EthernetSwitch
           name: ${awk::sprintf("%s (%s)", $9, $5)}
+          hw.network.name: $9
+          hw.network.alias: $10


### PR DESCRIPTION
* Add hw.network.name and hw.network.alias attributes